### PR TITLE
Make functional BST more-functional.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,18 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  docs:
+    name: Rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,6 @@
 //! in the tree. BSTs also naturally support sorted iteration by visiting the
 //! left subtree, then the subtree root, then the right subtree.
 
-#![deny(missing_docs)]
+#![deny(missing_docs, clippy::clone_on_ref_ptr)]
 
 pub mod functional;


### PR DESCRIPTION
**This Commit**
Adds history to the functional BST and no longer requires ownership to
`insert`/`delete`.

**Why?**
Mainly to make benchmarking easier but this has the benefit of more
closely matching a functional data structure in that, when new trees are
created from "mutating" operations, the history of trees/operations is
still accessible.