### PR TITLE
Make CI be one job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,85 +1,45 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
 
-name: CI
-
 jobs:
   check:
-    name: Check
+    name: CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: Checkout repo
+        uses: actions/checkout@v2
 
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
+          componentst: clippy, rustfmt
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v1.3.0
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
         with:
           command: test
 
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
 
-  docs:
-    name: Rustdoc
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
+      - name: Check docs
+        uses: actions-rs/cargo@v1
         with:
           command: doc
           args: --no-deps


### PR DESCRIPTION
**This Commit**
Makes several changes to the GitHub action configuration:

- Stops running CI on pushes to `main` because CI is run on branches and
  branches are be up to date before merging (one day I'll enforce this
  in the GH UI but for now I just always do it and this project doesn't
  really matter that much) so I don't care about this right now and it
  should save on minutes
- Combines all the job steps into one job so we can reuse a cache. This
  may take more real-world time since we lose parallelism but it should
  save on GH minutes
- Removes the `cargo check` step since there's a `clippy` step already