### PR TITLE
Fix `clippy` lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets -- -D warnings
 
       - name: Check docs
         uses: actions-rs/cargo@v1

--- a/benches/functional.rs
+++ b/benches/functional.rs
@@ -60,7 +60,7 @@ fn bench_helper(c: &mut Criterion, name: &str, f: impl Fn(&Tree<i32, i32>, i32))
 
             group.bench_with_input(id, &largest_element_in_tree, |b, _| {
                 b.iter(|| {
-                    let _ignored = f(&tree, largest_element_in_tree as i32);
+                    f(&tree, largest_element_in_tree as i32);
                 })
             });
         }

--- a/tests/quicktests/functional.rs
+++ b/tests/quicktests/functional.rs
@@ -57,7 +57,7 @@ fn contains_not(xs: Vec<i8>, nots: Vec<i8>) -> bool {
     let nots: HashSet<_> = nots.into_iter().collect();
     let mut nots = nots.difference(&added);
 
-    nots.all(|x| tree.find(x) == None)
+    nots.all(|x| tree.find(x).is_none())
 }
 
 #[quickcheck]


### PR DESCRIPTION
## This Commit

Addresses two `clippy` lints not caught by CI because they were in tests/benchmarks. It also updates CI to lint tests/benchmarks.