### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## This Commit

Adds Dependabot for GH Actions and crates.

## Why?

Because I'm too lazy to keep things updated on my own.