### PR TITLE
Null Pointer Optimization in Node children

### DIFF
--- a/src/functional.rs
+++ b/src/functional.rs
@@ -40,12 +40,8 @@ use std::rc::Rc;
 /// and deleting keys and values. Note that this data structure is
 /// functional - operations that would modify the tree instead
 /// return a new tree.
-pub enum Tree<K, V> {
-    /// A marker for the empty pointer at the bottom of a subtree.
-    Leaf,
-    /// A `Node` that has a key, value, and two children (which are
-    /// both `Tree`s). This enum trivially wraps the [`Node`] struct.
-    Node(Node<K, V>),
+pub struct Tree<K, V> {
+    root: Option<Node<K, V>>,
 }
 
 impl<K, V> Default for Tree<K, V> {
@@ -57,7 +53,7 @@ impl<K, V> Default for Tree<K, V> {
 impl<K, V> Tree<K, V> {
     /// Generates a new, empty `Tree`.
     pub fn new() -> Self {
-        Self::Leaf
+        Self { root: None }
     }
 
     /// Returns a new tree that includes a node
@@ -81,9 +77,13 @@ impl<K, V> Tree<K, V> {
     where
         K: cmp::Ord,
     {
-        match self {
-            Self::Leaf => Self::Node(Node::new(key, value)),
-            Self::Node(n) => Self::Node(n.insert(key, value)),
+        let new_root = match &self.root {
+            None => Node::new(key, value),
+            Some(root) => root.insert(key, value),
+        };
+
+        Self {
+            root: Some(new_root),
         }
     }
 
@@ -106,9 +106,9 @@ impl<K, V> Tree<K, V> {
     where
         K: cmp::Ord,
     {
-        match self {
-            Self::Leaf => None,
-            Self::Node(n) => n.find(k),
+        match &self.root {
+            None => None,
+            Some(n) => n.find(k),
         }
     }
 
@@ -134,62 +134,68 @@ impl<K, V> Tree<K, V> {
     where
         K: cmp::Ord,
     {
-        match self {
-            Self::Leaf => Self::new(),
-            Self::Node(n) => n.delete(k).map(Self::Node).unwrap_or_default(),
-        }
-    }
-
-    /// Gets the height of this tree.
-    fn height(&self) -> usize {
-        match self {
-            Self::Leaf => 0,
-            Self::Node(n) => n.height,
+        match &self.root {
+            None => Self::new(),
+            Some(n) => Self { root: n.delete(k) },
         }
     }
 }
 
-struct Child<K, V>(Rc<Tree<K, V>>);
+struct Child<K, V>(Option<Rc<Node<K, V>>>);
 impl<K, V> Clone for Child<K, V> {
     fn clone(&self) -> Self {
-        Self(Rc::clone(&self.0))
+        Self(self.0.clone())
     }
 }
 impl<K, V> Child<K, V> {
     fn new() -> Self {
-        Self(Rc::new(Tree::new()))
+        Self(None)
     }
 
     fn height(&self) -> usize {
-        self.0.height()
+        match &self.0 {
+            None => 0,
+            Some(n) => n.height,
+        }
     }
 
     fn insert(&self, key: K, value: V) -> Self
     where
         K: cmp::Ord,
     {
-        Self(Rc::new(self.0.insert(key, value)))
+        let new_node = match &self.0 {
+            Some(n) => n.insert(key, value),
+            None => Node::new(key, value),
+        };
+        Self(Some(Rc::new(new_node)))
     }
 
     fn find(&self, k: &K) -> Option<&V>
     where
         K: cmp::Ord,
     {
-        self.0.find(k)
+        match &self.0 {
+            Some(n) => n.find(k),
+            None => None,
+        }
     }
 
     fn delete(&self, k: &K) -> Self
     where
         K: cmp::Ord,
     {
-        Self(Rc::new(self.0.delete(k)))
+        let new_node = match &self.0 {
+            Some(n) => n.delete(k).map(Rc::new),
+            None => None,
+        };
+        Self(new_node)
     }
 }
 
 /// A `Node` has a key that is used for searching/sorting and a value
 /// that is associated with that key. It always has two children although
 /// those children may be [`Leaf`][Tree::Leaf]s.
-pub struct Node<K, V> {
+struct Node<K, V> {
     key: Rc<K>,
     value: Rc<V>,
     left: Child<K, V>,
@@ -286,16 +292,16 @@ impl<K, V> Node<K, V> {
                 let new_left = self.left.delete(k);
                 Some(self.clone_with_children(new_left, self.right.clone()))
             }
-            cmp::Ordering::Equal => match (self.left.0.as_ref(), self.right.0.as_ref()) {
-                (Tree::Leaf, Tree::Leaf) => None,
-                (Tree::Leaf, Tree::Node(right)) => Some(right.clone()),
-                (Tree::Node(left), Tree::Leaf) => Some(left.clone()),
+            cmp::Ordering::Equal => match (&self.left.0, &self.right.0) {
+                (None, None) => None,
+                (None, Some(right)) => Some(Node::clone(right)),
+                (Some(left), None) => Some(Node::clone(left)),
 
                 // If we have two children we have to figure out
                 // which node to promote. We choose here this node's
                 // predecessor. That is, the largest node in this node's
                 // left subtree.
-                (Tree::Node(left_child), _) => {
+                (Some(left_child), _) => {
                     let (pred_key, pred_val, new_left) = left_child.delete_largest();
                     let height = new_left.height().max(self.right.height()) + 1;
                     Some(
@@ -322,19 +328,19 @@ impl<K, V> Node<K, V> {
     where
         K: cmp::Ord,
     {
-        match self.right.0.as_ref() {
-            Tree::Leaf => (
+        match &self.right.0 {
+            None => (
                 Rc::clone(&self.key),
                 Rc::clone(&self.value),
                 self.left.clone(),
             ),
-            Tree::Node(r) => {
+            Some(r) => {
                 let (key, value, new_right) = r.delete_largest();
 
                 (
                     key,
                     value,
-                    Child(Rc::new(Tree::Node(
+                    Child(Some(Rc::new(
                         self.clone_with_children(self.left.clone(), new_right),
                     ))),
                 )
@@ -346,26 +352,26 @@ impl<K, V> Node<K, V> {
     /// invariant, we lift the right child's left child to be the new left child's right child.
     fn rotate_left(&self) -> Self {
         let old_root = self;
-        match &*old_root.right.0 {
+        match &old_root.right.0 {
             // We can't come into this method without a right child since we only rotate left if
             // the right subtree is taller than the left subtree.
-            Tree::Leaf => unreachable!("`balance` saw right child taller than left child."),
-            Tree::Node(new_root) => {
+            None => unreachable!("`balance` saw right child taller than left child."),
+            Some(new_root) => {
                 // The old root will be come the left child of the new root. It's left child stays
                 // the same and its right child is the left child of the new root (since the new
                 // root's left child is changing to be this node).
-                let new_left = Tree::Node(Self {
+                let new_left = Self {
                     height: old_root.left.height().max(new_root.left.height()) + 1,
                     key: Rc::clone(&old_root.key),
                     left: old_root.left.clone(),
                     right: new_root.left.clone(),
                     value: Rc::clone(&old_root.value),
-                });
+                };
 
                 Self {
-                    height: new_root.right.height().max(new_left.height()) + 1,
+                    height: new_root.right.height().max(new_left.height) + 1,
                     key: Rc::clone(&new_root.key),
-                    left: Child(Rc::new(new_left)),
+                    left: Child(Some(Rc::new(new_left))),
                     right: new_root.right.clone(),
                     value: Rc::clone(&new_root.value),
                 }
@@ -376,22 +382,22 @@ impl<K, V> Node<K, V> {
     /// Returns a new tree by rotating the left child up to become the root. To maintain the AVL
     /// invariant, we lift the left child's right child to be the new right child's left child.
     fn rotate_right(&self) -> Self {
-        match self.left.0.as_ref() {
-            Tree::Leaf => self.clone(),
-            Tree::Node(l) => {
-                let new_right = Tree::Node(Self {
+        match &self.left.0 {
+            None => self.clone(),
+            Some(l) => {
+                let new_right = Self {
                     height: self.right.height().max(l.right.height()) + 1,
                     key: Rc::clone(&self.key),
                     left: l.right.clone(),
                     right: self.right.clone(),
                     value: Rc::clone(&self.value),
-                });
+                };
 
                 Self {
-                    height: l.left.height().max(new_right.height()) + 1,
+                    height: l.left.height().max(new_right.height) + 1,
                     key: Rc::clone(&l.key),
                     left: l.left.clone(),
-                    right: Child(Rc::new(new_right)),
+                    right: Child(Some(Rc::new(new_right))),
                     value: Rc::clone(&l.value),
                 }
             }
@@ -489,9 +495,9 @@ mod tests {
     /// Assert the heights of the root, left child, and right child of a tree.
     macro_rules! assert_heights {
         ($tree:ident, $height:expr, $left_height:expr, $right_height:expr) => {{
-            assert_eq!($tree.height(), $height);
+            assert_eq!($tree.root.as_ref().map_or(0, |root| root.height), $height);
 
-            if let Tree::Node(n) = &$tree {
+            if let Some(n) = &$tree.root {
                 assert_eq!(n.height, $height);
 
                 assert_eq!(n.right.height(), $right_height);
@@ -503,7 +509,7 @@ mod tests {
     #[test]
     fn test_height() {
         let mut tree = Tree::new();
-        assert_eq!(tree.height(), 0);
+        assert_heights!(tree, 0, 0, 0);
 
         tree = tree.insert(1, 1);
         assert_heights!(tree, 1, 0, 0);


### PR DESCRIPTION
## This PR

Reworks `Node` children from `Rc<Tree>` (which is roughly `Rc<Option<Node>>`) to `Option<Rc<Node>>` to take advantage of the null pointer optimization there.

This is done in two commits. The first one introduces a new `Child` struct to make it easier to review the second commit which adds the `Option`al structure.

It's quite possible the `Child` struct can be removed at this point. Benchmarks for that should be investigated.

<details>
<summary>Benchmarks</summary>

Benchmarks for this branch (both commits together), with outliers removed, are:

```
find/unbalanced/6       time:   [3.2420 ns 3.2549 ns 3.2667 ns]
                        change: [+2.4473% +3.8006% +4.7412%] (p = 0.00 < 0.05)
                        Performance has regressed.
find/balanced/6         time:   [3.2638 ns 3.2666 ns 3.2693 ns]
                        change: [+4.0062% +4.4559% +4.8542%] (p = 0.00 < 0.05)
                        Performance has regressed.
find/unbalanced/126     time:   [7.0310 ns 7.0371 ns 7.0450 ns]
                        change: [-21.931% -21.745% -21.522%] (p = 0.00 < 0.05)
                        Performance has improved.
find/balanced/126       time:   [8.3811 ns 8.3910 ns 8.4046 ns]
                        change: [-22.623% -21.897% -21.012%] (p = 0.00 < 0.05)
                        Performance has improved.
find/unbalanced/2046    time:   [13.274 ns 13.276 ns 13.278 ns]
                        change: [-15.056% -14.603% -13.979%] (p = 0.00 < 0.05)
                        Performance has improved.
find/balanced/2046      time:   [14.408 ns 14.423 ns 14.439 ns]
                        change: [-19.763% -19.218% -18.512%] (p = 0.00 < 0.05)
                        Performance has improved.
find/unbalanced/32766   time:   [24.049 ns 24.097 ns 24.167 ns]
                        change: [-5.7962% -5.2063% -4.4081%] (p = 0.00 < 0.05)
                        Performance has improved.
find/balanced/32766     time:   [21.755 ns 21.761 ns 21.768 ns]
                        change: [-19.085% -18.789% -18.541%] (p = 0.00 < 0.05)
                        Performance has improved.

delete/unbalanced/6     time:   [51.879 ns 51.904 ns 51.932 ns]
                        change: [-26.296% -25.769% -25.140%] (p = 0.00 < 0.05)
                        Performance has improved.
delete/balanced/6       time:   [52.701 ns 52.770 ns 52.846 ns]
                        change: [-25.499% -24.855% -24.279%] (p = 0.00 < 0.05)
                        Performance has improved.
delete/unbalanced/126   time:   [180.46 ns 180.63 ns 180.83 ns]
                        change: [-8.7991% -8.2582% -7.7966%] (p = 0.00 < 0.05)
                        Performance has improved.
delete/balanced/126     time:   [211.67 ns 212.47 ns 214.01 ns]
                        change: [-7.7736% -7.1557% -6.4458%] (p = 0.00 < 0.05)
                        Performance has improved.
delete/unbalanced/2046  time:   [360.06 ns 360.20 ns 360.36 ns]
                        change: [-10.101% -9.2309% -8.0783%] (p = 0.00 < 0.05)
                        Performance has improved.
delete/balanced/2046    time:   [500.53 ns 501.32 ns 502.46 ns]
                        change: [-4.3721% -3.1968% -1.9218%] (p = 0.00 < 0.05)
                        Performance has improved.
delete/unbalanced/32766 time:   [594.57 ns 596.50 ns 598.92 ns]
                        change: [-7.2811% -6.0005% -4.8648%] (p = 0.00 < 0.05)
                        Performance has improved.
delete/balanced/32766   time:   [634.35 ns 635.54 ns 637.18 ns]
                        change: [-2.9938% -2.1631% -1.3887%] (p = 0.00 < 0.05)
                        Performance has improved.

insert/unbalanced/6     time:   [131.64 ns 132.16 ns 132.87 ns]
                        change: [-22.099% -18.188% -12.788%] (p = 0.00 < 0.05)
                        Performance has improved.
insert/balanced/6       time:   [132.10 ns 136.08 ns 141.57 ns]
                        change: [-37.461% -33.748% -29.746%] (p = 0.00 < 0.05)
                        Performance has improved.
insert/unbalanced/126   time:   [259.74 ns 260.07 ns 260.40 ns]
                        change: [-27.419% -26.643% -25.980%] (p = 0.00 < 0.05)
                        Performance has improved.
insert/balanced/126     time:   [472.11 ns 473.84 ns 476.33 ns]
                        change: [-8.9275% -8.1607% -7.3933%] (p = 0.00 < 0.05)
                        Performance has improved.
insert/unbalanced/2046  time:   [475.68 ns 476.29 ns 476.95 ns]
                        change: [-16.758% -15.418% -14.318%] (p = 0.00 < 0.05)
                        Performance has improved.
insert/balanced/2046    time:   [599.24 ns 599.93 ns 600.68 ns]
                        change: [-7.7128% -5.5058% -1.9537%] (p = 0.00 < 0.05)
                        Performance has improved.
insert/unbalanced/32766 time:   [691.80 ns 692.33 ns 692.94 ns]
                        change: [-15.379% -13.663% -11.858%] (p = 0.00 < 0.05)
                        Performance has improved.
insert/balanced/32766   time:   [895.05 ns 895.88 ns 896.99 ns]
                        change: [-7.9344% -7.1838% -6.3918%] (p = 0.00 < 0.05)
                        Performance has improved.

find-miss/unbalanced/6  time:   [2.7059 ns 2.7247 ns 2.7556 ns]
                        change: [-28.090% -27.424% -26.830%] (p = 0.00 < 0.05)
                        Performance has improved.
find-miss/balanced/6    time:   [2.6940 ns 2.7014 ns 2.7097 ns]
                        change: [-28.395% -27.776% -27.273%] (p = 0.00 < 0.05)
                        Performance has improved.
find-miss/unbalanced/126
                        time:   [7.7050 ns 7.7136 ns 7.7259 ns]
                        change: [-18.283% -17.956% -17.620%] (p = 0.00 < 0.05)
                        Performance has improved.
find-miss/balanced/126  time:   [8.5930 ns 8.6019 ns 8.6135 ns]
                        change: [-22.010% -21.761% -21.500%] (p = 0.00 < 0.05)
                        Performance has improved.
find-miss/unbalanced/2046
                        time:   [12.782 ns 12.791 ns 12.801 ns]
                        change: [-20.254% -19.833% -19.235%] (p = 0.00 < 0.05)
                        Performance has improved.
find-miss/balanced/2046 time:   [14.944 ns 14.952 ns 14.964 ns]
                        change: [-17.540% -17.080% -16.777%] (p = 0.00 < 0.05)
                        Performance has improved.
find-miss/unbalanced/32766
                        time:   [26.878 ns 26.893 ns 26.909 ns]
                        change: [+5.2232% +5.7561% +6.1261%] (p = 0.00 < 0.05)
                        Performance has regressed.
find-miss/balanced/32766
                        time:   [20.402 ns 20.411 ns 20.424 ns]
                        change: [-25.318% -24.863% -24.356%] (p = 0.00 < 0.05)
                        Performance has improved.

delete-miss/unbalanced/6
                        time:   [82.394 ns 82.628 ns 82.946 ns]
                        change: [-18.087% -17.520% -17.060%] (p = 0.00 < 0.05)
                        Performance has improved.
delete-miss/balanced/6  time:   [82.500 ns 82.728 ns 83.007 ns]
                        change: [-18.584% -17.829% -17.125%] (p = 0.00 < 0.05)
                        Performance has improved.
delete-miss/unbalanced/126
                        time:   [207.83 ns 208.21 ns 208.79 ns]
                        change: [-10.267% -9.4155% -8.5655%] (p = 0.00 < 0.05)
                        Performance has improved.
delete-miss/balanced/126
                        time:   [238.73 ns 239.41 ns 240.38 ns]
                        change: [-43.644% -43.171% -42.496%] (p = 0.00 < 0.05)
                        Performance has improved.
delete-miss/unbalanced/2046
                        time:   [406.43 ns 406.77 ns 407.15 ns]
                        change: [-9.6620% -8.6836% -7.9487%] (p = 0.00 < 0.05)
                        Performance has improved.
delete-miss/balanced/2046
                        time:   [528.08 ns 529.01 ns 530.28 ns]
                        change: [-5.1771% -3.9000% -3.0746%] (p = 0.00 < 0.05)
                        Performance has improved.
delete-miss/unbalanced/32766
                        time:   [647.03 ns 650.77 ns 656.06 ns]
                        change: [-3.0026% -1.3391% +0.9399%] (p = 0.14 > 0.05)
                        No change in performance detected.
delete-miss/balanced/32766
                        time:   [678.55 ns 678.85 ns 679.21 ns]
                        change: [-19.548% -18.782% -17.942%] (p = 0.00 < 0.05)
                        Performance has improved.
```

It looks like the regressions are spurious since improvements can be found
in the same class of benchmark with greater nodes.

</details>