### PR TITLE
Move quickchecks out of integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
 quickcheck = "1"
-quickcheck_macros = "1"
 
 [[bench]]
 name = "functional"

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -628,3 +628,93 @@ mod tests {
         assert_heights!(tree, 2, 1, 1);
     }
 }
+
+#[cfg(test)]
+mod quicktests {
+    use std::collections::{HashMap, HashSet};
+
+    use super::*;
+    use crate::test::quick::Op;
+
+    /// Applies a set of operations to a tree and a hashmap.
+    /// This way we can ensure that after a random smattering of inserts
+    /// and deletes we have the same set of keys in the map.
+    fn do_ops<K, V>(ops: &[Op<K, V>], mut bst: Tree<K, V>, map: &mut HashMap<K, V>) -> Tree<K, V>
+    where
+        K: std::hash::Hash + Eq + Clone + Ord,
+        V: std::fmt::Debug + PartialEq + Clone,
+    {
+        for op in ops {
+            match op {
+                Op::Insert(k, v) => {
+                    bst = bst.insert(k.clone(), v.clone());
+                    map.insert(k.clone(), v.clone());
+                }
+                Op::Remove(k) => {
+                    bst = bst.delete(k);
+                    map.remove(k);
+                }
+            }
+        }
+
+        bst
+    }
+
+    quickcheck::quickcheck! {
+        fn fuzz_multiple_operations_i8(ops: Vec<Op<i8, i8>>) -> bool {
+            let mut tree = Tree::new();
+            let mut map = HashMap::new();
+
+            tree = do_ops(&ops, tree, &mut map);
+            map.keys().all(|key| tree.find(key) == map.get(key))
+        }
+    }
+
+    quickcheck::quickcheck! {
+        fn contains(xs: Vec<i8>) -> bool {
+            let mut tree = Tree::new();
+            for x in &xs {
+                tree = tree.insert(*x, *x);
+            }
+
+            xs.iter().all(|x| tree.find(x) == Some(x))
+        }
+    }
+
+    quickcheck::quickcheck! {
+        fn contains_not(xs: Vec<i8>, nots: Vec<i8>) -> bool {
+            let mut tree = Tree::new();
+            for x in &xs {
+                tree = tree.insert(*x, *x);
+            }
+            let added: HashSet<_> = xs.into_iter().collect();
+            let nots: HashSet<_> = nots.into_iter().collect();
+            let mut nots = nots.difference(&added);
+
+            nots.all(|x| tree.find(x).is_none())
+        }
+    }
+
+    quickcheck::quickcheck! {
+        fn with_deletions(xs: Vec<i8>, deletes: Vec<i8>) -> bool {
+            let mut tree = Tree::new();
+            for x in &xs {
+                tree = tree.insert(*x, *x);
+            }
+            for delete in &deletes {
+                tree = tree.delete(delete);
+            }
+
+            let mut still_present = xs;
+            for delete in &deletes {
+                // We may have inserted the same value multiple times - delete each one.
+                while let Some(pos) = still_present.iter().position(|x| x == delete) {
+                    still_present.swap_remove(pos);
+                }
+            }
+
+            deletes.iter().all(|x| tree.find(x).is_none())
+                && still_present.iter().all(|x| tree.find(x).is_some())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,6 @@
 #![deny(missing_docs, clippy::clone_on_ref_ptr)]
 
 pub mod functional;
+
+#[cfg(test)]
+mod test;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod quick;

--- a/src/test/quick.rs
+++ b/src/test/quick.rs
@@ -1,14 +1,9 @@
-#[macro_use(quickcheck)]
-extern crate quickcheck_macros;
-
 use quickcheck::{Arbitrary, Gen};
-
-mod quicktests;
 
 /// An enum for the various kinds of "things" to do to
 /// binary search trees in a quicktest.
 #[derive(Copy, Clone, Debug)]
-pub enum Op<K, V> {
+pub(crate) enum Op<K, V> {
     /// Insert the K, V into the data structure
     Insert(K, V),
     /// Remove the K from the data structure


### PR DESCRIPTION
## Why?

Mostly just for expectations. I like the idea of fuzzing the public interface. That's still happening. But I also like being able to fuzz the private interface if need be. Also, my `cfg!(test)` mistake before was because I expected the quickchecks to validate this behavior and they didn't because they were integration tests. So this should be more clear without sacrificing anything I'm aware of.