### PR TITLE
Remove invalid rustdoc link in Node docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: rustdoc
-          args: --lib -- -D warnings
+          args: --lib -- -D warnings --document-private-items
 
       - name: Run tests
         uses: actions-rs/cargo@v1

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -194,7 +194,7 @@ impl<K, V> Child<K, V> {
 
 /// A `Node` has a key that is used for searching/sorting and a value
 /// that is associated with that key. It always has two children although
-/// those children may be [`Leaf`][Tree::Leaf]s.
+/// those children may be `Tree::Leaf`s.
 struct Node<K, V> {
     key: Rc<K>,
     value: Rc<V>,


### PR DESCRIPTION
## This Commit

Removes the `[Tree::Leaf]` doc link that doesn't go anywhere because you can't link to a variant and updates CI to catch things like this in the future.