### PR TITLE
Add ability to `Clone` trees

### DIFF
--- a/src/immutable.rs
+++ b/src/immutable.rs
@@ -44,6 +44,14 @@ pub struct Tree<K, V> {
     root: Option<Node<K, V>>,
 }
 
+impl<K, V> Clone for Tree<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            root: self.root.clone(),
+        }
+    }
+}
+
 impl<K, V> Default for Tree<K, V> {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
## This Commit

Adds `Clone` implementations for the immutable and unsafe trees.

## Why?

Because, for the unsafe case at least, it's an interesting thing to learn how to do. It also simplifies the benchmarks a little.