### PR TITLE
Enable sharing GH Action Cache across branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
## This Commit

Runs the CI action on pushes to `main`.

## Why?

This creates a cache that lives on `main` which, because `main` is the default branch, is then accessible on all branches. By default, [sibling branches cannot share a cache][0]. Because of this, I saw that [new PRs weren't sharing caches from old PRs][^1][^2]. This should hopefully fix that.

[0]: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
[^1]: https://github.com/mlodato517/rust_bst/actions/runs/4428287946/jobs/7767145421#step:3:22
[^2]: https://github.com/mlodato517/rust_bst/actions/runs/4428436760/jobs/7767514408#step:3:14