### PR TITLE
Add tree-based iterator to immutable tree

### DIFF
--- a/src/bangsafe.rs
+++ b/src/bangsafe.rs
@@ -1208,6 +1208,7 @@ mod quicktests {
                 Op::Remove(k) => {
                     assert_eq!(bst.delete(k), map.remove(k));
                 }
+                Op::Iter => {}
             }
         }
     }

--- a/src/test/quick.rs
+++ b/src/test/quick.rs
@@ -8,6 +8,8 @@ pub(crate) enum Op<K, V> {
     Insert(K, V),
     /// Remove the K from the data structure
     Remove(K),
+    /// Compare iterators
+    Iter,
 }
 
 impl<K, V> Arbitrary for Op<K, V>
@@ -17,9 +19,10 @@ where
 {
     /// Tells quickcheck how to randomly choose an operation
     fn arbitrary(g: &mut Gen) -> Self {
-        match g.choose(&[0, 1]).unwrap() {
+        match g.choose(&[0, 1, 2]).unwrap() {
             0 => Op::Insert(K::arbitrary(g), V::arbitrary(g)),
             1 => Op::Remove(K::arbitrary(g)),
+            2 => Op::Iter,
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
## This Commit

Allows for iterating over references of the key-value pairs in an immutable tree.

## Why?

Because this is a standard collections interface we should support. Also it's a good learning opportunity because it's sneaky-hard.

## Up Next

I do not like what I came up with one bit haha. I know I saw something about this in the Nomicon way back when so I'm going to go look that up now and update with the changes.

### Update

Well, after looking at the Nomicon, it seems like this is more-or-less The Way so :tada:?