### PR TITLE
Avoid unnecessary allocation in delete-miss

### DIFF
--- a/src/bangsafe.rs
+++ b/src/bangsafe.rs
@@ -30,6 +30,8 @@ use std::fmt;
 use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 
+use crate::util::DeleteResult;
+
 /// Marker value for a `Node`'s height when its value has been removed during deletion. This is
 /// used to ensure that the value isn't re-dropped in `Node::drop`.
 const VALUE_REMOVED: usize = 0;
@@ -200,17 +202,6 @@ impl<K, V> Tree<K, V> {
         // reference).
         unsafe { self.root.as_mut().map(|root| root.as_mut()) }
     }
-}
-
-enum DeleteResult<V> {
-    /// The key wasn't found so nothing was deleted.
-    NotFound,
-    /// The Node returning this is being deleted and has no children to replace itself with. The
-    /// parent who receives this should drop the child and remove its value using
-    /// [`Node::take_value`].
-    DeleteSelf,
-    /// A child node was deleted yielding the value `V` which can be returned to the parent.
-    DeletedChild(V),
 }
 
 struct Node<K, V> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,5 +28,7 @@
 pub mod bangsafe;
 pub mod immutable;
 
+pub(crate) mod util;
+
 #[cfg(test)]
 mod test;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,9 @@
+pub(crate) enum DeleteResult<V> {
+    /// The key wasn't found so nothing was deleted.
+    NotFound,
+    /// The Node returning this is being deleted and has no children. Its parent can take its `V`
+    /// before dropping it.
+    DeleteSelf,
+    /// A child node was deleted yielding the value `V`.
+    DeletedChild(V),
+}


### PR DESCRIPTION
## This Commit

Uses `bangsafe`'s `DeleteResult` construct to avoid unnecessary `Rc::new`ing when trying to delete a node that isn't there.

## Why?

Previously, `Child::Delete` would call `Rc::new` on the result of `n.delete(k)` regardless of what happened. This means that, if `n.delete(k)` did nothing, we'd allocate a new `Rc` instead of cloning an existing one. See [this comment][0] for more details.

## Benchmarks

Ignoring `find`, `insert`, and `find-miss` since those codepaths weren't touched, we see:

```
delete/immutable/6          time:   [58.097 ns 58.167 ns 58.250 ns]
                            change: [+12.429% +12.732% +13.025%]
                            Performance has regressed.
delete/immutable/126        time:   [161.59 ns 161.74 ns 161.91 ns]
                            change: [+11.545% +11.783% +12.023%]
                            Performance has regressed.
delete/immutable/2046       time:   [306.21 ns 306.81 ns 307.88 ns]
                            change: [+1.7977% +2.2199% +2.5886%]
                            Performance has regressed.
delete/immutable/32766      time:   [494.58 ns 495.30 ns 496.57 ns]
                            change: [+6.8019% +7.0829% +7.3743%]
                            Performance has regressed.
delete-miss/immutable/6     time:   [34.370 ns 34.401 ns 34.438 ns]
                            change: [-51.402% -51.225% -51.080%]
                            Performance has improved.
delete-miss/immutable/126   time:   [45.142 ns 45.171 ns 45.200 ns]
                            change: [-73.200% -73.095% -73.020%]
                            Performance has improved.
delete-miss/immutable/2046  time:   [57.241 ns 57.282 ns 57.327 ns]
                            change: [-82.457% -82.430% -82.402%]
                            Performance has improved.
delete-miss/immutable/32766 time:   [67.454 ns 67.489 ns 67.527 ns]
                            change: [-86.728% -86.697% -86.672%]
                            Performance has improved.
```

which is expected. `delete` is now doing more work because it's tracking whether or not the value was found. So when the value _is_ found, we're doing extra work for "nothing"*. However, in `delete-miss`, we now avoid unnecessary allocations of new `Rc`s so there are huge improvements.

\* I say this is for "nothing" but I don't really mean it. Realistically, `Tree::delete` should return the value of the deleted node and `DeleteResult` is a reasonable place to store that because the caller needs both the new tree and the `Option<Rc<V>>`. Because of this, I'm okay with the hit to `delete` and a future PR should add the deleted value to the return value of `delete`.

[0]: https://github.com/mlodato517/rust_bst/pull/17#discussion_r1120728564